### PR TITLE
Feature/message pack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "lsl-sys 0.1.0",
  "rmp-serde 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "serialport 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -471,6 +472,14 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -730,6 +739,7 @@ dependencies = [
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+"checksum serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "325a073952621257820e7a3469f55ba4726d8b28657e7e36653d1c36dc2c84ae"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 "checksum serialport 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8d3ecaf58010bedccae17be55d4ed6f2ecde5646fc48ce8c66ea2d35a1419c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ base64 = "0.11.0"
 byteorder = "1.3.2"
 uuid = {version= "0.8.1", features=["v5"]}
 signal-hook = "0.1.12"
+serde_bytes = "0.11"
 
 [lib]
 name = "hackeeg"

--- a/lsl-sys/src/lib.rs
+++ b/lsl-sys/src/lib.rs
@@ -102,6 +102,12 @@ impl StreamInfo<i32> {
     }
 }
 
+#[cfg(target_pointer_width = "64")]
+type PtrWidth = u64;
+
+#[cfg(target_pointer_width = "32")]
+type PtrWidth = u32;
+
 pub struct Outlet<Format> {
     info: StreamInfo<Format>,
     handle: bindings::lsl_outlet,
@@ -110,7 +116,12 @@ pub struct Outlet<Format> {
 impl Outlet<i32> {
     pub fn push_chunk(&self, data: &[i32], timestamp: f64) -> i32 {
         unsafe {
-            bindings::lsl_push_chunk_it(self.handle, data.as_ptr(), data.len() as usize, timestamp)
+            bindings::lsl_push_chunk_it(
+                self.handle,
+                data.as_ptr(),
+                data.len() as PtrWidth,
+                timestamp,
+            )
         }
     }
 }
@@ -118,7 +129,12 @@ impl Outlet<i32> {
 impl Outlet<f32> {
     pub fn push_chunk(&self, data: &[f32], timestamp: f64) -> i32 {
         unsafe {
-            bindings::lsl_push_chunk_ft(self.handle, data.as_ptr(), data.len() as usize, timestamp)
+            bindings::lsl_push_chunk_ft(
+                self.handle,
+                data.as_ptr(),
+                data.len() as PtrWidth,
+                timestamp,
+            )
         }
     }
 }

--- a/lsl-sys/src/lib.rs
+++ b/lsl-sys/src/lib.rs
@@ -110,7 +110,7 @@ pub struct Outlet<Format> {
 impl Outlet<i32> {
     pub fn push_chunk(&self, data: &[i32], timestamp: f64) -> i32 {
         unsafe {
-            bindings::lsl_push_chunk_it(self.handle, data.as_ptr(), data.len() as u64, timestamp)
+            bindings::lsl_push_chunk_it(self.handle, data.as_ptr(), data.len() as usize, timestamp)
         }
     }
 }
@@ -118,7 +118,7 @@ impl Outlet<i32> {
 impl Outlet<f32> {
     pub fn push_chunk(&self, data: &[f32], timestamp: f64) -> i32 {
         unsafe {
-            bindings::lsl_push_chunk_ft(self.handle, data.as_ptr(), data.len() as u64, timestamp)
+            bindings::lsl_push_chunk_ft(self.handle, data.as_ptr(), data.len() as usize, timestamp)
         }
     }
 }

--- a/src/bin/hackeeg_stream.rs
+++ b/src/bin/hackeeg_stream.rs
@@ -77,7 +77,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .arg(
             Arg::with_name("channel_test")
                 .short("T")
-                .long("chanel-test")
+                .long("channel-test")
                 .help("Set the channels to internal test settings for software testing")
         )
         .arg(

--- a/src/bin/hackeeg_stream.rs
+++ b/src/bin/hackeeg_stream.rs
@@ -127,7 +127,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .parse::<u32>()?
             .into();
         info!(target: MAIN_TAG, "Configuring channels with gain {}", gain);
-        client.enable_all_channels(Some(gain));
+        client.enable_all_channels(Some(gain))?;
     }
 
     // Route reference electrode to SRB1: JP8:1-2, JP7:NC (not connected)

--- a/src/client/commands/responses.rs
+++ b/src/client/commands/responses.rs
@@ -30,9 +30,17 @@ impl From<Status> for Box<dyn std::error::Error> {
 }
 
 #[derive(Deserialize, Clone, Debug)]
-pub struct Sample {
+pub struct JSONPayload {
     #[serde(rename = "C")]
     pub code: u32,
     #[serde(rename = "D")]
     pub data: String,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct MessagepackPayload {
+    #[serde(rename = "C")]
+    pub code: u32,
+    #[serde(rename = "D", with = "serde_bytes")]
+    pub data: Vec<u8>,
 }

--- a/src/client/commands/responses.rs
+++ b/src/client/commands/responses.rs
@@ -36,11 +36,3 @@ pub struct JSONPayload {
     #[serde(rename = "D")]
     pub data: String,
 }
-
-#[derive(Deserialize, Clone, Debug)]
-pub struct MessagepackPayload {
-    #[serde(rename = "C")]
-    pub code: u32,
-    #[serde(rename = "D", with = "serde_bytes")]
-    pub data: Vec<u8>,
-}

--- a/src/client/err.rs
+++ b/src/client/err.rs
@@ -4,7 +4,7 @@ use base64::DecodeError;
 #[derive(Debug)]
 pub enum ClientError {
     IOError(std::io::Error),
-    DeserializeError(serde_json::error::Error),
+    DeserializeError(Box<dyn std::error::Error>),
     BadStatus(Status),
     InvalidBase64(base64::DecodeError),
     Other(Box<dyn std::error::Error>),
@@ -18,7 +18,13 @@ impl From<std::io::Error> for ClientError {
 
 impl From<serde_json::error::Error> for ClientError {
     fn from(e: serde_json::error::Error) -> Self {
-        ClientError::DeserializeError(e)
+        ClientError::DeserializeError(Box::new(e))
+    }
+}
+
+impl From<rmp_serde::decode::Error> for ClientError {
+    fn from(e: rmp_serde::decode::Error) -> Self {
+        ClientError::DeserializeError(Box::new(e))
     }
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -54,10 +54,10 @@ impl HackEEGClient {
         Ok(client)
     }
 
-    pub fn enable_all_channels(&self) -> ClientResult<()> {
+    pub fn enable_all_channels(&self, gain: Option<ads1299::Gain>) -> ClientResult<()> {
         info!(target: CLIENT_TAG, "Enabling all channels");
         for chan_idx in 1..=constants::NUM_CHANNELS {
-            self.enable_channel(chan_idx as u8, None)?
+            self.enable_channel(chan_idx as u8, gain)?
         }
         Ok(())
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -56,7 +56,7 @@ impl HackEEGClient {
 
     pub fn enable_all_channels(&self, gain: Option<ads1299::Gain>) -> ClientResult<()> {
         info!(target: CLIENT_TAG, "Enabling all channels");
-        for chan_idx in 1..=constants::NUM_CHANNELS + 1 {
+        for chan_idx in 1..=constants::NUM_CHANNELS {
             self.enable_channel(chan_idx as u8, gain)?
         }
         Ok(())
@@ -159,7 +159,7 @@ impl HackEEGClient {
 
     pub fn disable_all_channels(&self) -> ClientResult<()> {
         info!(target: CLIENT_TAG, "Disabling all channels");
-        for chan_idx in 1..=constants::NUM_CHANNELS + 1 {
+        for chan_idx in 1..=constants::NUM_CHANNELS {
             self.disable_channel(chan_idx as u8)?;
         }
         Ok(())

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -300,9 +300,9 @@ impl HackEEGClient {
 
     fn messagepack_read(&self) -> ClientResult<sample::Sample> {
         let mut port = self.port.borrow_mut();
-        let payload: commands::responses::MessagepackPayload =
-            rmp_serde::from_read(port.get_mut())?;
-        let sample = payload.data.as_slice().into();
+        let mut mp_buf = [0; constants::MP_MESSAGE_SIZE];
+        port.read_exact(&mut mp_buf)?;
+        let sample = mp_buf[constants::MP_BINARY_OFFSET..].into();
         Ok(sample)
     }
 

--- a/src/client/sample.rs
+++ b/src/client/sample.rs
@@ -14,7 +14,7 @@ impl From<&[u8]> for Channel {
     }
 }
 
-pub struct Payload {
+pub struct Sample {
     pub timestamp: u32,
     pub sample_number: u32,
     pub ads_status: u32,
@@ -25,7 +25,7 @@ pub struct Payload {
     pub channels: [Channel; NUM_CHANNELS],
 }
 
-impl Payload {
+impl Sample {
     pub fn as_lsl_data(&self) -> Vec<i32> {
         vec![
             self.channels[0].sample,
@@ -38,10 +38,8 @@ impl Payload {
             self.channels[7].sample,
         ]
     }
-}
 
-impl From<&[u8]> for Payload {
-    fn from(data: &[u8]) -> Self {
+    pub fn from_bytes(data: &[u8]) -> Self {
         let timestamp = u32::from_le_bytes(data[0..4].try_into().unwrap());
         let sample_number = u32::from_le_bytes(data[4..8].try_into().unwrap());
 
@@ -71,5 +69,18 @@ impl From<&[u8]> for Payload {
             extra,
             channels,
         }
+    }
+}
+
+impl From<&[u8]> for Sample {
+    fn from(data: &[u8]) -> Self {
+        Self::from_bytes(data)
+    }
+}
+
+impl From<String> for Sample {
+    fn from(data: String) -> Self {
+        let decoded = base64::decode(data.as_bytes()).unwrap();
+        Self::from_bytes(decoded.as_slice())
     }
 }

--- a/src/common/constants/ads1299.rs
+++ b/src/common/constants/ads1299.rs
@@ -185,7 +185,7 @@ pub const MUXn0: u8 = 0x01;
 //
 
 // http://www.ti.com/lit/ds/symlink/ads1299.pdf  pg 50
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum Gain {
     X1 = 0b0,
     X2 = 0b001,
@@ -208,6 +208,21 @@ impl fmt::Display for Gain {
             Self::X24 => "X24",
         };
         write!(f, "Gain {}", s)
+    }
+}
+
+impl From<u32> for Gain {
+    fn from(num: u32) -> Self {
+        match num {
+            1 => Gain::X1,
+            2 => Gain::X2,
+            4 => Gain::X4,
+            6 => Gain::X6,
+            8 => Gain::X8,
+            12 => Gain::X12,
+            24 => Gain::X24,
+            _ => panic!("Invalid gain"),
+        }
     }
 }
 

--- a/src/common/constants/mod.rs
+++ b/src/common/constants/mod.rs
@@ -1,3 +1,7 @@
 pub mod ads1299;
 
 pub const NUM_CHANNELS: usize = 8;
+
+// message pack manual sizes and offsets, for faster decoding
+pub const MP_MESSAGE_SIZE: usize = 44;
+pub const MP_BINARY_OFFSET: usize = 9;


### PR DESCRIPTION
* added messagepack with `-M` or `--messagepack`
* added gain with `-g` or `--gain`
* channel test is disabled by default, enable with `-T` or `--channel-test`

There's still a couple of issues I'm seeing on my machine:

1. signal noise when `--sps 16000`
2. can't achieve more than 12k/s (but neither can the python client)
3. i can't seem to read in jsonlines mode after messagepack streaming, without resetting the board